### PR TITLE
[Fixes #4] Fix .travis.yml and improve build-deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 **/*.rs.bk
 /Cargo.lock
+*.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ matrix:
 addons:
     apt:
         packages:
-            # Needed for i686-unknown-linux-gnu target.
+            # Needed for `i686-unknown-linux-gnu` target (e.g. 32bit support).
             - gcc-multilib
-              # Needed to build deb packages.
+              # Needed to build Debian packages.
             - fakeroot
 
 install:
@@ -61,7 +61,7 @@ script:
     - cargo test --target $TARGET --verbose
 
 before_deploy:
-    - ./ci/before-deploy
+    - ./ci/travis/before-deploy $TRAVIS_TEST_RESULT $TARGET $PROJECT_NAME $TRAVIS_TAG
 
 deploy:
     provider: releases
@@ -72,19 +72,20 @@ deploy:
     # - Paste the output below.
     api_key:
         secure: "o9/2FyTlDBQUQOfLLbSQVix641TFuBXkCEa6OXX09/3U3yMg1SAr85i+KIyzj/6HlkyJnOVodR3qQ+0r+qh1t0TF9h06Z4EBUzs0LGTgd2Gh0muZZ8JDG9Vv/+z6Qk3NnLDdCVmRjXy46+fRo/IXVxQLwbPE/a8WB+b7lIcwY3DXQyP+CNJD5W6pYJw/v/Q20/+ADcNokPaoLlnr/R5vB1BWwcWE6NYiOsID4Qa7Ya9zvbdDFIP8Qbrxi5bt2imfF4MX/TkqrY6VYXC87UQt6oiooMx9lswmxWGVSIJLD2Edz90fGwsgmirNMm/tfzZv/xKUUAai/DBZ5vimH58DCRerg7LJ3V/8s8EARwYh+gAnFncwQVUiNEnXSboUX1Y604tm656NiGORDiOFOmdSEoif8broibTFmPhPquzza2pZA+uGOkEj1X/rN/ksMW6Qt4TbVQ8frhkhHI/oZ8HrLiv8P5iRJOBJoGQvRxG6nRCfSy5UVIAlZUxvn0D4mwmiUDYu0RuIn50cZeDh6vuij2RkL/fBntNQAS0p6xmWyYC441fcCBTBCuiBoSNBYLQyF3qUEHMV1vH1PEoHm5blwjyYn6zME4Te/Ao0Iqj1Z1VIpfKnN0mUzb46Zs9LFLUI7rtBhATLeVISA4wC0b9PStXd5aJNsQcflwkfYAPOGe8="
-        # For uploading multiple files.
-        file_glob: true
-        # **NOTE** Explanation on each env variable:
-        # - PROJECT_NAME: Name of the project, set on the `env.global` above.
-        # - TRAVIS_TAG: Tag name that the build is being deployed for, usually the version number.
-        # - TARGET: Target triple of the build.
-        file:
-            - $PROJECT_NAME-$TRAVIS_TAG-$TARGET.*
-            - $PROJECT_NAME*.deb
-        # Don't delete artifacts from previous stage.
-        skip_cleanup: true
-        on:
-            # Deploy only if we push a tag.
-            tags: true
-            # Deploy only on stable channel that has TARGET env variable sets.
-            condition: $TRAVIS_RUST_VERSION = stable && $TARGET != ""
+    # Upload multiple files.
+    file_glob: true
+    # **NOTE** Explanation on each env variable:
+    # - PROJECT_NAME: Name of the project, set on the `env.global` above.
+    # - TRAVIS_TAG: Tag name that the build is being deployed for, usually the version number.
+    # - TARGET: Target triple of the build.
+    file:
+        - $PROJECT_NAME-$TRAVIS_TAG-$TARGET.*
+        - $PROJECT_NAME*.deb
+    # Don't delete artifacts from previous stage.
+    skip_cleanup: true
+    on:
+        # Deploy only if we push a tag.
+        tags: true
+        # Deploy only on stable channel that has TARGET env variable sets.
+        condition: $TRAVIS_RUST_VERSION = stable && $TARGET != ""
+    all_branches: true

--- a/ci/travis/before-deploy
+++ b/ci/travis/before-deploy
@@ -230,6 +230,29 @@ EOF
   return 0
 }
 
+# Function: usage
+#
+# Print the help message and usage example.
+#
+# Returns:
+# 0 for success.
+usage() {
+  cat >&2 <<USAGE
+
+Build a release version of the project and package it as a tarball package, and also
+as a Debian package if the platform is Linux.
+
+Usage:
+  before-deploy <TRAVIS_TEST_RESULT> <TARGET> <PROJECT_NAME> <TRAVIS_TAG>
+
+Options:
+  TRAVIS_TEST_RESULT  0 to proceed, otherwise will exit early.
+  TARGET              The platform triple to build for.
+  PROJECT_NAME        The name of the project to find the binary & name the packages.
+  TRAVIS_TAG          The version (tag) of the package, e.g. "v0.1.0".
+USAGE
+}
+
 #
 # MAIN
 #
@@ -238,14 +261,57 @@ if [[ "${DEBUG_BEFORE_DEPLOY:-false}" == true ]]; then
   set -x
 fi
 
-# shellcheck disable=SC2153
-cargo_build "${TARGET}"
+if [[ $# -ne 4 ]]; then
+  log_error "Incorrect # of args, expected 4 but only [$#]: [$*]"
+  usage
+  exit 1
+fi
+
+declare -r arg_travis_test_result="${1}" && shift
+declare -r arg_target="${1}" && shift
+declare -r arg_project_name="${1}" && shift
+declare -r arg_travis_tag="${1}" && shift
+
+if [[ -z "${arg_travis_test_result}" ]]; then
+  log_error "Argument 'travis_test_result' is empty"
+  usage
+  exit 1
+fi
+
+if [[ -z "${arg_target}" ]]; then
+  log_error "Argument 'target' is empty"
+  usage
+  exit 1
+fi
+
+if [[ -z "${arg_project_name}" ]]; then
+  log_error "Argument 'project_name' is empty"
+  usage
+  exit 1
+fi
+
+if [[ -z "${arg_travis_tag}" ]]; then
+  log_error "Argument 'travis_tag' is empty"
+  usage
+  exit 1
+fi
+
+if [[ "${arg_travis_test_result}" -ne 0 ]]; then
+  log_info "Build failed, not executing pre-deploy commands"
+
+  # Don't want to fail everything (it's probably already failed),
+  # just exit early.
+  exit 0
+fi
 
 # shellcheck disable=SC2153
-create_archive_package "${TARGET}" "${PROJECT_NAME}" "${TRAVIS_TAG}"
+cargo_build "${arg_target}"
 
-if [[ "${TARGET}" == *linux* ]]; then
-  create_debian_package "${TARGET}" "${PROJECT_NAME}" "${TRAVIS_TAG}"
+# shellcheck disable=SC2153
+create_archive_package "${arg_target}" "${arg_project_name}" "${arg_travis_tag}"
+
+if [[ "${arg_target}" == *linux* ]]; then
+  create_debian_package "${arg_target}" "${arg_project_name}" "${arg_travis_tag}"
 fi
 
 exit 0


### PR DESCRIPTION
Fix bad indenting in `deploy` section of `.travis.yml`, also add support
for deploying from all branches to support better testing.

Move `before-deploy` script to `ci/travis` sub-dir, improve argument
validation, and switch to using cmdline arguments instead of environment
variables. Also add usage statement.