### PR TITLE
Follow the embedded-hal interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ rust:
     - stable
     - beta
     - nightly
-    # Oldest supported Rust version.
-    - 1.24.0
 os:
     # OSX is explicitly `include`d in the matrix below as we don't need to build
     # all the linux 32/64+gnu/musl combinations for it.
@@ -38,9 +36,6 @@ matrix:
           env: TARGET=x86_64-apple-darwin
         - os: osx
           rust: nightly
-          env: TARGET=x86_64-apple-darwin
-        - os: osx
-          rust: 1.24.0
           env: TARGET=x86_64-apple-darwin
 
 branches:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name    = "led_bargraph"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Jason Peacock <jason@jasonpeacock.com>"]
 description = "A Rust library & application for the Adafruit Bi-Color (Red/Green) 24-Bar Bargraph w/I2C Backpack Kit."
-keywords = ["led", "gpio", "driver", "bargraph", "display"]
+keywords = ["led", "driver", "display", "embedded-hal"]
 categories = ["hardware-support"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jasonpeacock/led-bargraph"
@@ -16,15 +16,19 @@ exclude = ["/ci/*"]
 [dependencies]
 ansi_term     = "0.11.0"
 docopt        = "1.0.2"
-ht16k33       = "0.1.0"
-i2cdev        = "0.4.0"
+embedded-hal  = "0.2.2"
+ht16k33       = "0.2.0"
+num-integer   = "0.1.39"
 serde         = "1.0.80"
 serde_derive  = "1.0.80"
-slog          = "2.4.1"
+slog          = {version = "2.4.1", features = ["max_level_trace"]}
 slog-async    = "2.3.0"
 slog-stdlog   = "3.0.4-pre"
 slog-term     = "2.4.0"
 slog-scope    = "4.0.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+linux-embedded-hal = "0.2.2"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "jasonpeacock/led-bargraph" }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,11 @@
+# Releasing new crates
+
+1. Run `cargo update` to refresh dependencies.
+1. Run `cargo outdated` and fix any advice.
+1. Run `touch src/lib.rs && cargo clippy` and fix any advice.
+1. Run `cargo clean && cargo build && cargo test` to double-check everything is happy.
+1. Update the version info in `Cargo.toml` as appropriate.
+1. Dry-run the publish: `cargo publish --dry-run --allow-dirty`
+1. Git push the change, wait for CI to pass.
+1. Tag the commit & push it: `git tag vX.Y.Z; git push --tags`
+1. Publish the crate: `cargo publish`

--- a/src/bin/led-bargraph.rs
+++ b/src/bin/led-bargraph.rs
@@ -1,7 +1,6 @@
 extern crate docopt;
 
 extern crate ht16k33;
-extern crate i2cdev;
 extern crate led_bargraph;
 
 #[macro_use]
@@ -13,28 +12,66 @@ extern crate slog_async;
 extern crate slog_term;
 
 use docopt::Docopt;
-use ht16k33::HT16K33;
 use led_bargraph::Bargraph;
 use slog::Drain;
 
-// LinuxI2CDevice only works on linux, use a mock
+use std::result;
+use std::sync::atomic::Ordering;
+use std::sync::{atomic, Arc};
+
+// Custom Drain logic to support enabling different log levels.
+struct RuntimeLevelFilter<D> {
+    drain: D,
+    debug: Arc<atomic::AtomicBool>,
+    trace: Arc<atomic::AtomicBool>,
+}
+
+impl<D> Drain for RuntimeLevelFilter<D>
+where
+    D: Drain,
+{
+    type Ok = Option<D::Ok>;
+    type Err = Option<D::Err>;
+
+    fn log(
+        &self,
+        record: &slog::Record,
+        values: &slog::OwnedKVList,
+    ) -> result::Result<Self::Ok, Self::Err> {
+        let current_level = if self.trace.load(Ordering::Relaxed) {
+            slog::Level::Trace
+        } else if self.debug.load(Ordering::Relaxed) {
+            slog::Level::Debug
+        } else {
+            slog::Level::Info
+        };
+
+        if record.level().is_at_least(current_level) {
+            self.drain.log(record, values).map(Some).map_err(Some)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+// The Linux I2cdevice only works on linux, use a mock
 // object to support compilation & testing on other
 // platforms (e.g. OSX).
 //
 // Linux
 #[cfg(target_os = "linux")]
-use i2cdev::linux::LinuxI2CDevice;
+extern crate linux_embedded_hal;
+#[cfg(target_os = "linux")]
+use linux_embedded_hal::I2cdev;
 //
 // Not Linux
 //
-// The `MockI2CDevice` from `i2cdev` is only available
-// for test builds, and is very basic. Use the more
-// capable and available `MockI2CDevice` from `ht16k33`.
+// Use the `I2cMock` provided by `ht16k33`.
 #[cfg(not(target_os = "linux"))]
-use ht16k33::i2c_mock::MockI2CDevice;
+use ht16k33::i2c_mock::I2cMock;
 
 // Docopts: https://github.com/docopt/docopt.rs
-const USAGE: &'static str = "
+const USAGE: &str = "
 LED Bargraph.
 
 Usage:
@@ -53,9 +90,11 @@ Arguments:
     range   The range of the bar graph to display.
 
 Options:
-    -h --help               Print this help.
+    -h, --help              Print this help.
+    -d, --debug             Enable verbose debug logging.
+    --trace                 Enable extra-verbose trace logging.
+    --as-is                 Assume device is already initialized.
     --show                  Show on-screen the current bargraph display.
-    --steps=<N>             Resolution of the bargraph [default: 24].
     --i2c-path=<path>       Path to the I2C device [default: /dev/i2c-1].
     --i2c-address=<N>       Address of the I2C device, in decimal [default: 112].
 ";
@@ -67,17 +106,32 @@ struct Args {
     cmd_show: bool,
     arg_value: u8,
     arg_range: u8,
+    flag_debug: bool,
+    flag_trace: bool,
+    flag_as_is: bool,
     flag_show: bool,
-    flag_steps: u8,
     flag_i2c_path: String,
-    flag_i2c_address: u16,
+    flag_i2c_address: u8,
 }
 
 fn main() {
-    // Setup logging for the terminal (STDERR).
+    let debug = Arc::new(atomic::AtomicBool::new(false));
+    let trace = Arc::new(atomic::AtomicBool::new(false));
+
+    // Setup logging for the terminal (e.g. STDERR).
     let decorator = slog_term::TermDecorator::new().build();
     let drain = slog_term::FullFormat::new(decorator).build().fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
+    let drain = RuntimeLevelFilter {
+        drain,
+        debug: debug.clone(),
+        trace: trace.clone(),
+    }
+    .fuse();
+    let drain = slog_async::Async::new(drain)
+        // It's OK to block on logging if we log too fast (e.g. `trace`).
+        .overflow_strategy(slog_async::OverflowStrategy::Block)
+        .build()
+        .fuse();
 
     let logger = slog::Logger::root(drain, o!());
 
@@ -85,53 +139,64 @@ fn main() {
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());
 
+    // Enable debug logging if requested. If both `--debug` and `--trace` are enabled,
+    // then log level will be trace.
+    debug.store(args.flag_debug, Ordering::Relaxed);
+    trace.store(args.flag_trace, Ordering::Relaxed);
+
     debug!(logger, "{:?}", args);
 
-    let device_logger = logger.new(o!("mod" => "HT16K33"));
-
-    // LinuxI2CDevice only works on linux, otherwise use a mock
-    // object to support compilation & testing.
+    // The Linux I2cdevice only works on linux, use a mock object to support compilation & testing.
     //
     // Linux
     #[cfg(target_os = "linux")]
-    let i2c_device = LinuxI2CDevice::new(args.flag_i2c_path, args.flag_i2c_address).unwrap();
+    let mut i2c_device = I2cdev::new(args.flag_i2c_path).unwrap();
+    #[cfg(target_os = "linux")]
+    i2c_device
+        .set_slave_address(args.flag_i2c_address as u16)
+        .unwrap();
     //
     // Not Linux
     #[cfg(not(target_os = "linux"))]
     let mock_logger = logger.new(o!("mod" => "HT16K33::i2c_mock"));
     #[cfg(not(target_os = "linux"))]
-    let i2c_device = MockI2CDevice::new(mock_logger);
-
-    let mut device = HT16K33::new(i2c_device, args.flag_steps, device_logger).unwrap();
-    device.initialize().unwrap();
+    let i2c_device = I2cMock::new(mock_logger);
 
     let bargraph_logger = logger.new(o!("mod" => "bargraph"));
-    let mut bargraph = Bargraph::new(device, args.flag_show, bargraph_logger);
+    let mut bargraph = Bargraph::new(
+        i2c_device,
+        args.flag_i2c_address,
+        args.flag_show,
+        bargraph_logger,
+    );
 
-    bargraph
-        .initialize()
-        .expect("Could not initialize bargraph");
+    if args.flag_as_is {
+        info!(logger, "Not initializing the display");
+        bargraph
+            .initialize()
+            .expect("Failed to initialize the display");
+    }
 
     if args.cmd_clear {
         info!(logger, "Clearing the display");
-        bargraph.clear().expect("Could not clear the display");
+        bargraph.clear().expect("Failed to clear the display");
     }
 
     if args.cmd_set {
-        info!(logger, "Setting a value in the range on the display";
+        info!(logger, "Setting a value within a range on the display";
               "value" => args.arg_value, "range" => args.arg_range);
 
         bargraph
             .update(args.arg_value, args.arg_range)
-            .expect("Could not update the display");
+            .expect("Failed to set a value within a range on the display");
     }
 
     if args.cmd_show {
-        info!(logger, "Showing on-screen the current bargraph display");
+        info!(logger, "Showing the current display on-screen");
 
         bargraph
             .show()
-            .expect("Could not show on-screen the current bargraph display");
+            .expect("Failed to show the current display on-screen");
     }
 
     debug!(logger, "Success");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,92 +1,65 @@
 //! # Bargraph
 //!
 //! A library for the [Adafruit Bi-Color (Red/Green) 24-Bar Bargraph w/I2C Backpack Kit](https://www.adafruit.com/product/1721).
-
+//!
+//! The HT16K33 has 16 rows by 8 commons for controlling 128 LEDs (#0-127). This is represented internally
+//! by an array of size 16 of type u8, where each lower bit of the u8 value denotes a common:
+//!
+//! __   0   2   4   8  16  32  64 128
+//! 00   0   1   2   3   4   5   6   7
+//! 01   8   9  10  11  12  13  14  15
+//! ...
+//! 14 112 113 114 115 116 117 118 119
+//! 15 120 121 122 123 124 125 126 127
+//!
+//! The LED address (N) can be converted to a buffer location by modulo `8` to calculate the row,
+//! then left-shifted by the remainder to calculate the common:
+//!
+//! LED #11 -> row 1, common 8 (e.g. 1 << 3)
+//!
 extern crate ansi_term;
+extern crate embedded_hal as hal;
 extern crate ht16k33;
-extern crate i2cdev;
+extern crate num_integer;
 
 #[macro_use]
 extern crate slog;
 extern crate slog_stdlog;
 
-use std::error;
-use std::fmt;
+use ansi_term::Colour::{Fixed, Green, Red, White, Yellow};
 
-use ansi_term::Colour::{Fixed, White, Green, Yellow, Red};
+use hal::blocking::i2c::{Write, WriteRead};
 
-use ht16k33::HT16K33Error;
-use i2cdev::core::I2CDevice;
+use ht16k33::HT16K33;
+
+use num_integer::Integer;
 
 use slog::Drain;
-use slog::Logger;
-use slog_stdlog::StdLog;
 
-pub enum BargraphError<D>
-where
-    D: I2CDevice,
-{
-    /// Error from the connected `HT16K33` device.
-    HT16K33(HT16K33Error<D>),
-    /// Error from `bargraph`.
-    Error,
-}
-
-impl<D> fmt::Debug for BargraphError<D>
-where
-    D: I2CDevice,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "BargraphError: {:?}", self)
-    }
-}
-
-impl<D> fmt::Display for BargraphError<D>
-where
-    D: I2CDevice,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            BargraphError::HT16K33(ref err) => write!(f, "HT16K33 error: {}", err),
-            BargraphError::Error => write!(f, "Bargraph Error"),
-        }
-    }
-}
-
-impl<D> error::Error for BargraphError<D>
-where
-    D: I2CDevice + fmt::Debug,
-{
-    fn description(&self) -> &str {
-        match *self {
-            BargraphError::HT16K33(ref err) => err.description(),
-            BargraphError::Error => "Bargraph Error",
-        }
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        match *self {
-            BargraphError::HT16K33(ref err) => Some(err),
-            BargraphError::Error => None,
-        }
-    }
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LedColor {
+    /// Turn off both the Red & Green LEDs.
+    Off,
+    /// Turn on only the Green LED.
+    Green,
+    /// Turn on only the Red LED.
+    Red,
+    /// Turn on both the Red  & Green LEDs.
+    Yellow,
 }
 
 const BARGRAPH_DISPLAY_CHAR: &str = "\u{258A}";
+const BARGRAPH_RESOLUTION: u8 = 24;
 
-pub struct Bargraph<D>
-where
-    D: I2CDevice,
-{
-    device: ht16k33::HT16K33<D>,
-    is_ready: bool,
-    logger: Logger,
+pub struct Bargraph<I2C> {
+    device: HT16K33<I2C>,
     show: bool,
+    logger: slog::Logger,
 }
 
-impl<D> Bargraph<D>
+impl<I2C, E> Bargraph<I2C>
 where
-    D: I2CDevice,
+    I2C: Write<Error = E> + WriteRead<Error = E>,
 {
     /// Create a Bargraph for display.
     ///
@@ -104,180 +77,48 @@ where
     ///
     /// The `Into` [trick](http://xion.io/post/code/rust-optional-args.html) allows
     /// passing `Logger` directly, without the `Some` part.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// // NOTE: `None` is used for the Logger in these examples for convenience,
-    /// // in practice using an actual logger is preferred.
-    ///
-    /// extern crate ht16k33;
-    /// extern crate led_bargraph;
-    ///
-    /// use ht16k33::HT16K33;
-    /// use ht16k33::i2c_mock::MockI2CDevice;
-    /// use led_bargraph::Bargraph;
-    ///
-    /// fn main() {
-    ///
-    /// // Create a mock I2C device.
-    /// let i2c_device = MockI2CDevice::new(None);
-    ///
-    /// // Create a connected display.
-    /// let mut device = HT16K33::new(i2c_device, 24, None).unwrap();
-    /// device.initialize().unwrap();
-    ///
-    /// // Create a Bargraph instance.
-    /// let mut bargraph = Bargraph::new(device, false, None);
-    ///
-    /// }
-    /// ```
-    pub fn new<L>(
-        device: ht16k33::HT16K33<D>,
-        show: bool,
-        logger: L,
-    ) -> Bargraph<D>
+    pub fn new<L>(i2c: I2C, i2c_address: u8, show: bool, logger: L) -> Self
     where
-        L: Into<Option<Logger>>,
+        L: Into<Option<slog::Logger>>,
     {
-        let logger = logger.into().unwrap_or(Logger::root(StdLog.fuse(), o!()));
+        let logger = logger
+            .into()
+            .unwrap_or_else(|| slog::Logger::root(slog_stdlog::StdLog.fuse(), o!()));
 
-        debug!(logger, "Constructing Bargraph");
+        trace!(logger, "Constructing Bargraph");
+
+        let ht16k33_logger = logger.new(o!("mod" => "HT16K33"));
+        let ht16k33 = HT16K33::new(i2c, i2c_address, ht16k33_logger);
 
         Bargraph {
-            device: device,
-            is_ready: false,
-            logger: logger,
-            show: show,
+            device: ht16k33,
+            show,
+            logger,
         }
     }
 
     /// Initialize the Bargraph display & the connected `HT16K33` device.
-    ///
-    /// # Errors
-    ///
-    /// * `BargraphError` - Either the Bargraph display or connected `HT16K33`
-    /// device could not be initialized.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # extern crate ht16k33;
-    /// # extern crate led_bargraph;
-    /// #
-    /// # use ht16k33::HT16K33;
-    /// # use ht16k33::i2c_mock::MockI2CDevice;
-    /// # use led_bargraph::Bargraph;
-    /// #
-    /// # fn main() {
-    /// # let i2c_device = MockI2CDevice::new(None);
-    /// # let mut device = HT16K33::new(i2c_device, 24, None).unwrap();
-    /// # device.initialize().unwrap();
-    /// #
-    /// // Create a Bargraph instance.
-    /// let mut bargraph = Bargraph::new(device, false, None);
-    ///
-    /// // Initialize the bargraph.
-    /// bargraph.initialize();
-    /// # }
-    /// ```
-    pub fn initialize(&mut self) -> Result<(), BargraphError<D>> {
-        debug!(self.logger, "Initializing Bargraph");
-
-        if ! self.device.is_ready() {
-            return Err(BargraphError::Error);
-        }
+    pub fn initialize(&mut self) -> Result<(), E> {
+        trace!(self.logger, "initialize");
 
         // Reset the display.
-        debug!(self.logger, "Turning on display (disable blink)");
-        let _ = self.device.set_blink(ht16k33::BLINK_OFF).map_err(BargraphError::HT16K33);
-        debug!(self.logger, "Setting display to full brightness");
-        let _ = self.device.set_brightness(15).map_err(BargraphError::HT16K33);
-
-        // All initializations finished, ready to use.
-        self.is_ready = true;
+        self.device.initialize()?;
 
         Ok(())
     }
 
-    /// Check if the Bargraph display is ready.
-    ///
-    /// The Bargraph must be initialized to be ready to be used, as well
-    /// as the connected `HT16K33` device.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # extern crate ht16k33;
-    /// # extern crate led_bargraph;
-    /// #
-    /// # use ht16k33::HT16K33;
-    /// # use ht16k33::i2c_mock::MockI2CDevice;
-    /// # use led_bargraph::Bargraph;
-    /// #
-    /// # fn main() {
-    /// # let i2c_device = MockI2CDevice::new(None);
-    /// # let mut device = HT16K33::new(i2c_device, 24, None).unwrap();
-    /// # device.initialize().unwrap();
-    /// #
-    /// // Create a Bargraph instance.
-    /// let mut bargraph = Bargraph::new(device, false, None);
-    ///
-    /// // Not ready to use yet.
-    /// assert_eq!(false, bargraph.is_ready());
-    ///
-    /// // Initialize the bargraph.
-    /// bargraph.initialize();
-    ///
-    /// // Ready to use.
-    /// assert_eq!(true, bargraph.is_ready());
-    /// # }
-    /// ```
-    pub fn is_ready(&mut self) -> bool {
-        self.device.is_ready() && self.is_ready
-    }
-
     /// Clear the Bargraph display.
-    ///
-    /// # Errors
-    ///
-    /// * `BargraphError` - The display could not be updated.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # extern crate ht16k33;
-    /// # extern crate led_bargraph;
-    /// #
-    /// # use ht16k33::HT16K33;
-    /// # use ht16k33::i2c_mock::MockI2CDevice;
-    /// # use led_bargraph::Bargraph;
-    /// #
-    /// # fn main() {
-    /// # let i2c_device = MockI2CDevice::new(None);
-    /// # let mut device = HT16K33::new(i2c_device, 24, None).unwrap();
-    /// # device.initialize().unwrap();
-    /// #
-    /// // Create a Bargraph instance.
-    /// let mut bargraph = Bargraph::new(device, false, None);
-    /// bargraph.initialize();
-    ///
-    /// bargraph.clear();
-    /// # }
-    /// ```
-    pub fn clear(&mut self) -> Result<(), BargraphError<D>> {
-        if ! self.is_ready() {
-            return Err(BargraphError::Error);
-        }
+    pub fn clear(&mut self) -> Result<(), E> {
+        trace!(self.logger, "clear");
 
-        self.device.clear().map_err(BargraphError::HT16K33)?;
-        self.device.write_display().map_err(BargraphError::HT16K33)
+        self.device.clear_display_buffer();
+        self.device.write_display_buffer()
     }
 
     /// Update the Bargraph display, showing `range` total bars with all bars
-    /// from `0` to `bar` filled.
+    /// from `0` to `value` filled.
     ///
-    /// If `bar` is greater than `range`, then all bars are filled and will blink;
+    /// If `value` is greater than `range`, then all bars are filled and will blink;
     /// automatic re-scaling of the range does *not* happen because:
     ///
     /// * The bargraph can only scale to a maximum resolution.
@@ -288,66 +129,33 @@ where
     ///
     /// # Arguments
     ///
-    /// * `bar` - How many bars to fill, starting from `0`.
-    /// * `range` - Total number of bars to display.
-    ///
-    /// # Errors
-    ///
-    /// * `BargraphError` - The display could not be updated.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # extern crate ht16k33;
-    /// # extern crate led_bargraph;
-    /// #
-    /// # use ht16k33::HT16K33;
-    /// # use ht16k33::i2c_mock::MockI2CDevice;
-    /// # use led_bargraph::Bargraph;
-    /// #
-    /// # fn main() {
-    /// # let i2c_device = MockI2CDevice::new(None);
-    /// # let mut device = HT16K33::new(i2c_device, 24, None).unwrap();
-    /// # device.initialize().unwrap();
-    /// #
-    /// // Create a Bargraph instance & initialize it.
-    /// let mut bargraph = Bargraph::new(device, false, None);
-    /// bargraph.initialize();
-    ///
-    /// // Display a bargraph with 3 of 12 bars filled.
-    /// bargraph.update(3u8, 12u8);
-    /// # }
-    /// ```
+    /// * `value` - How many values to fill, starting from `0`.
+    /// * `range` - Total number of values to display.
     // TODO accept more user-friendly input values?
-    pub fn update(&mut self, bar: u8, range: u8) -> Result<(), BargraphError<D>> {
-        if ! self.is_ready() {
-            return Err(BargraphError::Error);
-        }
+    pub fn update(&mut self, value: u8, range: u8) -> Result<(), E> {
+        trace!(self.logger, "update");
 
         // Reset the display in preparation for the update.
-        self.device.clear().map_err(BargraphError::HT16K33)?;
+        self.device.clear_display_buffer();
 
         let mut blink = false;
-        let mut value = bar;
+        let mut clamped_value = value;
 
         if value > range {
-            warn!(self.logger, "Bar value is greater than range, setting display to blink";
-                  "bar" => bar, "range" => range);
-            value = range;
+            warn!(self.logger, "Value is greater than range, setting display to blink";
+                  "value" => value, "range" => range);
+            clamped_value = range;
             blink = true;
         }
 
-        for current_bar in 1..(range + 1) {
-            let mut fill = false;
-            if current_bar <= value {
-                fill = true;
-            }
-            self.set_bar_fill(&(current_bar - 1), &range, &fill);
+        for current_value in 1..=range {
+            let fill = current_value <= clamped_value;
+            self.update_value_fill(current_value - 1, range, fill);
         }
 
-        self.set_blink(&blink)?;
+        self.device.write_display_buffer()?;
 
-        self.device.write_display().map_err(BargraphError::HT16K33)?;
+        self.set_blink(blink)?;
 
         if self.show {
             self.show()?;
@@ -357,60 +165,38 @@ where
     }
 
     /// Show on-screen the current bargraph display.
-    ///
-    /// # Errors
-    ///
-    /// * `BargraphError` - The bargraph could not be displayed.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # extern crate ht16k33;
-    /// # extern crate led_bargraph;
-    /// #
-    /// # use ht16k33::HT16K33;
-    /// # use ht16k33::i2c_mock::MockI2CDevice;
-    /// # use led_bargraph::Bargraph;
-    /// #
-    /// # fn main() {
-    /// # let i2c_device = MockI2CDevice::new(None);
-    /// # let mut device = HT16K33::new(i2c_device, 24, None).unwrap();
-    /// # device.initialize().unwrap();
-    /// #
-    /// // Create a Bargraph instance & initialize it.
-    /// let mut bargraph = Bargraph::new(device, false, None);
-    /// bargraph.initialize();
-    ///
-    /// // Show on-screen the current bargraph display.
-    /// bargraph.show();
-    /// # }
-    /// ```
-    pub fn show(&mut self) -> Result<(), BargraphError<D>> {
-        debug!(self.logger, "Showing current bargraph display");
+    pub fn show(&mut self) -> Result<(), E> {
+        trace!(self.logger, "show");
 
         // Read current values from the device.
-        self.device.read_display().map_err(BargraphError::HT16K33)?;
+        self.device.read_display_buffer()?;
 
         // Convert values for display.
 
         // Display the values.
         // Unicode box-drawing characters: https://en.wikipedia.org/wiki/Box-drawing_character
-        println!("{corner_top_left}{line}{corner_top_right}",
-                 corner_top_left=White.paint("\u{2554}"),
-                 line=White.paint(std::iter::repeat("\u{2550}").take(9).collect::<String>()),
-                 corner_top_right=White.paint("\u{2557}"));
+        println!(
+            "{corner_top_left}{line}{corner_top_right}",
+            corner_top_left = White.paint("\u{2554}"),
+            line = White.paint(std::iter::repeat("\u{2550}").take(9).collect::<String>()),
+            corner_top_right = White.paint("\u{2557}")
+        );
 
-        println!("{side}{yellow}{yellow}{red}{black}{black}{green}{black}{black}{green}{side}",
-                 side=White.paint("\u{2551}"),
-                 green=Green.paint(BARGRAPH_DISPLAY_CHAR),
-                 yellow=Yellow.paint(BARGRAPH_DISPLAY_CHAR),
-                 red=Red.paint(BARGRAPH_DISPLAY_CHAR),
-                 black=Fixed(238).paint(BARGRAPH_DISPLAY_CHAR));
+        println!(
+            "{side}{yellow}{yellow}{red}{black}{black}{green}{black}{black}{green}{side}",
+            side = White.paint("\u{2551}"),
+            green = Green.paint(BARGRAPH_DISPLAY_CHAR),
+            yellow = Yellow.paint(BARGRAPH_DISPLAY_CHAR),
+            red = Red.paint(BARGRAPH_DISPLAY_CHAR),
+            black = Fixed(238).paint(BARGRAPH_DISPLAY_CHAR)
+        );
 
-        println!("{corner_bottom_left}{line}{corner_bottom_right}",
-                 corner_bottom_left=White.paint("\u{255A}"),
-                 line=White.paint(std::iter::repeat("\u{2550}").take(9).collect::<String>()),
-                 corner_bottom_right=White.paint("\u{255D}"));
+        println!(
+            "{corner_bottom_left}{line}{corner_bottom_right}",
+            corner_bottom_left = White.paint("\u{255A}"),
+            line = White.paint(std::iter::repeat("\u{2550}").take(9).collect::<String>()),
+            corner_bottom_right = White.paint("\u{255D}")
+        );
 
         Ok(())
     }
@@ -420,83 +206,99 @@ where
     /// # Arguments
     ///
     /// * `enabled` - Whether to enabled blinking or not.
-    ///
-    /// # Errors
-    ///
-    /// * `BargraphError` - The display could not be updated.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # extern crate ht16k33;
-    /// # extern crate led_bargraph;
-    /// #
-    /// # use ht16k33::HT16K33;
-    /// # use ht16k33::i2c_mock::MockI2CDevice;
-    /// # use led_bargraph::Bargraph;
-    /// #
-    /// # fn main() {
-    /// # let i2c_device = MockI2CDevice::new(None);
-    /// # let mut device = HT16K33::new(i2c_device, 24, None).unwrap();
-    /// # device.initialize().unwrap();
-    /// #
-    /// // Create a Bargraph instance & initialize it.
-    /// let mut bargraph = Bargraph::new(device, false, None);
-    /// bargraph.initialize();
-    ///
-    /// // Make the bargraph blink continuously.
-    /// bargraph.set_blink(&true);
-    /// # }
-    pub fn set_blink(&mut self, enabled: &bool) -> Result<(), BargraphError<D>> {
-        if ! self.is_ready() {
-            return Err(BargraphError::Error);
-        }
+    pub fn set_blink(&mut self, enabled: bool) -> Result<(), E> {
+        trace!(self.logger, "set_blink"; "enabled" => enabled);
 
-        if *enabled {
+        if enabled {
             self.device
-                .set_blink(ht16k33::BLINK_2HZ)
-                .map_err(BargraphError::HT16K33)
+                .set_display(ht16k33::Display::On, ht16k33::Blink::TwoHz)
         } else {
             self.device
-                .set_blink(ht16k33::BLINK_OFF)
-                .map_err(BargraphError::HT16K33)
+                .set_display(ht16k33::Display::On, ht16k33::Blink::Off)
         }
     }
 
-    // Enable/disable the fill for a `bar` on the Bargraph display.
+    // Enable/disable the fill for a `value` on the Bargraph display.
     //
     // # Arguments
     //
-    // * `bar` - Which bar to fill.
-    // * `range` - The total range of the display (for calculating the bar size).
-    // * `fill` - Whether to fill (true) the bar or only display its header.
+    // * `value` - Which value to fill.
+    // * `range` - The total range of the display (for calculating the value size).
+    // * `fill` - Whether to fill (true) the value or only display its header.
     //
     // # Notes
     //
-    // Bar `0` is at the bottom of the display (lowest value).
-    fn set_bar_fill(&mut self, bar: &u8, range: &u8, fill: &bool) {
-        // Calculate the size of the bar.
-        let bar_size = self.device.get_resolution() / *range;
+    // Value `0` is at the bottom of the display (lowest value).
+    fn update_value_fill(&mut self, value: u8, range: u8, fill: bool) {
+        trace!(self.logger, "update_value_fill"; "value" => value, "range" => range, "fill" => fill);
 
-        let start_bar = *bar * bar_size;
-        let end_bar = start_bar + bar_size - 1;
+        // Calculate the size of the value.
+        let value_size = BARGRAPH_RESOLUTION / range;
 
-        // Fill in the bar.
-        for bar in start_bar..end_bar {
-            if *fill {
+        let start_value = value * value_size;
+        let end_value = start_value + value_size - 1;
+
+        // Fill in the value.
+        for current_value in start_value..end_value {
+            if fill {
                 // Make the fill yellow if it's ON.
-                let _ = self.device.set_bar(bar, ht16k33::COLOR_YELLOW).map_err(BargraphError::HT16K33);
+                let _ = self.update_value_(current_value, LedColor::Yellow);
             } else {
-                // Leave it empty if above an ON bar.
-                let _ = self.device.set_bar(bar, ht16k33::COLOR_OFF).map_err(BargraphError::HT16K33);
+                // Leave it empty if above an ON value.
+                let _ = self.update_value_(current_value, LedColor::Off);
             }
         }
 
-        // Color the bar header (end of bar).
-        if *fill {
-            let _ = self.device.set_bar(end_bar, ht16k33::COLOR_RED);
+        // Color the value header (end of value).
+        if fill {
+            let _ = self.update_value_(end_value, LedColor::Red);
         } else {
-            let _ = self.device.set_bar(end_bar, ht16k33::COLOR_GREEN);
+            let _ = self.update_value_(end_value, LedColor::Green);
         }
+    }
+
+    // Set value_to desired color. Value should be a value of 0 to 23, and color should be
+    // OFF, GREEN, RED, or YELLOW.
+    //
+    // The buffer must be written using [write_display_buffer()](struct.HT16K33.html#method.write_display_buffer)
+    // for the change to be displayed.
+    //
+    // # Arguments
+    //
+    // * `value_- A value from `0` to `23`.
+    // * `color` - A valid color value.
+    fn update_value_(&mut self, value: u8, color: LedColor) -> Result<(), E> {
+        // TODO use Option to return only errors for these void functions
+        // TODO Validate `value` parameter.
+        trace!(self.logger, "update_value"; "value" => value, "color" => format!("{:?}", color));
+
+        let (count, remainder) = value.div_mod_floor(&12);
+        let (row, mut common) = remainder.div_mod_floor(&4);
+        let red_row = row * 2;
+        let green_row = red_row + 1;
+        common += count * 4;
+
+        if color == LedColor::Green || color == LedColor::Yellow {
+            let _ = self
+                .device
+                .update_display_buffer(ht16k33::LedLocation::new(green_row, common).unwrap(), true);
+        } else {
+            let _ = self.device.update_display_buffer(
+                ht16k33::LedLocation::new(green_row, common).unwrap(),
+                false,
+            );
+        }
+
+        if color == LedColor::Red || color == LedColor::Yellow {
+            let _ = self
+                .device
+                .update_display_buffer(ht16k33::LedLocation::new(red_row, common).unwrap(), true);
+        } else {
+            let _ = self
+                .device
+                .update_display_buffer(ht16k33::LedLocation::new(red_row, common).unwrap(), false);
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This closes #12.

* Minor version bump `0.1.0` -> `0.2.0` due to API changes.
* Rewrite implementation to follow the `embedded-hal` interface.
* Rewrite the API to be more consistent and move bargraph specific
features from `ht16k33`.
    * Add `--debug` and `--trace` log levels.
    * Add `--as-is` to skip chip initialization if desired.
    * Add initial (trivial) `--show/show` support. (Issue #6)
    * Use Enums for feature values.
    * Hardcode the resolution, will need to make configurable later
    (Issue #13).
    * Make `clippy` happy.
* Added `embedded-hal` keyword for `crates.io`, since we're now
compliant :)