### PR TITLE
Implement `--show` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,12 @@ rust:
     - nightly
 os:
     # OSX is explicitly `include`d in the matrix below as we don't need to build
-    # all the linux 32/64+gnu/musl combinations for it.
+    # all the linux 32/64+gnu combinations for it.
     - linux
 env:
     matrix:
         - TARGET=x86_64-unknown-linux-gnu
-        - TARGET=x86_64-unknown-linux-musl
         - TARGET=i686-unknown-linux-gnu
-        - TARGET=i686-unknown-linux-musl
     global:
         # Default target on `travis-ci`, used as conditional check in the `install` stage.
         - HOST=x86_64-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "led_bargraph"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Jason Peacock <jason@jasonpeacock.com>"]
 description = "A Rust library & application for the Adafruit Bi-Color (Red/Green) 24-Bar Bargraph w/I2C Backpack Kit."
 keywords = ["led", "driver", "display", "embedded-hal"]
@@ -17,7 +17,7 @@ exclude = ["/ci/*"]
 ansi_term     = "0.11.0"
 docopt        = "1.0.2"
 embedded-hal  = "0.2.2"
-ht16k33       = "0.2.0"
+ht16k33       = "0.3.0"
 num-integer   = "0.1.39"
 serde         = "1.0.80"
 serde_derive  = "1.0.80"


### PR DESCRIPTION
Closes #6.

Display the LED bargraph in the terminal. Supports colors, blinking,
etc. Can either show the value/range that was just set (`--show`) or
used alone as a command (`show`) to read the current value/range from
the LED bargraph and display it.

* Uses new `0.3.0` version of `HT16K33` library.
* Renamed option `--as-is` to be `--no-init`, now correctly skips
initialization of the bargraph if desired (avoids flicker when updating
an already-active display).
* Added `--verbose` logging option for `INFO` log level.
* Added docs and testing.

Also, disable CI for `*-musl` platforms, as they fail with a
missing `proc_macro` dependency failure due to not being able to load
dynamic libraries. It looks like this is introduced from `serde_derive`?